### PR TITLE
Add TCP port number to JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Example only with the `-j/--json` argument which shows the JSON only. Perfect fo
 
 ```
 narbeh@narbeh-xps:~/ssl-checker$ ./ssl_checker.py -j -H  narbeh.org:443 test.com
-{"narbeh.org": {"issued_to": "narbeh.org", "cert_sans": "DNS:narbeh.org", "valid_till": "2019-12-26", "valid_from": "2019-09-27", "issuer_ou": null, "days_left": 25, "cert_ver": 2, "cert_alg": "sha256WithRSAEncryption", "issued_o": null, "cert_exp": false, "cert_sha1": "05:52:4E:89:1E:98:1D:40:C1:41:F4:DD:F7:51:86:20:27:CF:E7:7F", "issuer_c": "US", "issuer_cn": "Let's Encrypt Authority X3", "issuer_o": "Let's Encrypt", "validity_days": 90, "cert_sn": 293690843427182569577385918507679703674563}}
+{"narbeh.org": {"issued_to": "narbeh.org", "cert_sans": "DNS:narbeh.org", "valid_till": "2019-12-26", "valid_from": "2019-09-27", "issuer_ou": null, "days_left": 25, "cert_ver": 2, "tcp_port": 443, "cert_alg": "sha256WithRSAEncryption", "issued_o": null, "cert_exp": false, "cert_sha1": "05:52:4E:89:1E:98:1D:40:C1:41:F4:DD:F7:51:86:20:27:CF:E7:7F", "issuer_c": "US", "issuer_cn": "Let's Encrypt Authority X3", "issuer_o": "Let's Encrypt", "validity_days": 90, "cert_sn": 293690843427182569577385918507679703674563}}
 ```
 
 

--- a/ssl_checker.py
+++ b/ssl_checker.py
@@ -200,7 +200,7 @@ def show_result(user_args):
         try:
             cert = get_cert(host, port, user_args)
             context[host] = get_cert_info(host, cert)
-            context[host]['tcp_port'] = port
+            context[host]['tcp_port'] = int(port)
 
             # Analyze the certificate if enabled
             if user_args.analyze:

--- a/ssl_checker.py
+++ b/ssl_checker.py
@@ -200,6 +200,7 @@ def show_result(user_args):
         try:
             cert = get_cert(host, port, user_args)
             context[host] = get_cert_info(host, cert)
+            context[host]['tcp_port'] = port
 
             # Analyze the certificate if enabled
             if user_args.analyze:

--- a/ssl_checker.py
+++ b/ssl_checker.py
@@ -116,7 +116,7 @@ def get_cert_info(host, cert):
     context['issuer_o'] = cert.get_issuer().organizationName
     context['issuer_ou'] = cert.get_issuer().organizationalUnitName
     context['issuer_cn'] = cert.get_issuer().commonName
-    context['cert_sn'] = cert.get_serial_number()
+    context['cert_sn'] = str(cert.get_serial_number())
     context['cert_sha1'] = cert.digest('sha1').decode()
     context['cert_alg'] = cert.get_signature_algorithm().decode()
     context['cert_ver'] = cert.get_version()


### PR DESCRIPTION
The following small patch includes the TCP port number in the JSON output. This is interesting (to me) when I use the `-f file` option to read hostnames and port numbers from a file

```
example.com
server.example.org:8883
```

In this instance, `tcp_port` in the JSON would be `443` for the first and `8883` for the second host, thereby permitting me to more closely identify which host I’m currently reading from the JSON output.
