### PR TITLE
add host to csv output

### DIFF
--- a/ssl_checker.py
+++ b/ssl_checker.py
@@ -110,6 +110,7 @@ def get_cert_info(host, cert):
 
     cert_subject = cert.get_subject()
 
+    context['host'] = host
     context['issued_to'] = cert_subject.CN
     context['issued_o'] = cert_subject.O
     context['issuer_c'] = cert.get_issuer().countryName


### PR DESCRIPTION
Noticed that when exporting to csv the host field was missing, this is useful to have when scanning multiple hosts.